### PR TITLE
新規ルーム作成のエラー修正

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -9,7 +9,7 @@ class RoomsController < ApplicationController
     if @room.save
       redirect_to root_path
     else
-      render :index
+      redirect_to root_path
     end
   end
   def destroy


### PR DESCRIPTION
＃What
新規ルーム作成で空のデータを送信するとエラーが起っていた為修正。